### PR TITLE
Fix MissingValues.Octo parsing imprecision for big numbers

### DIFF
--- a/src/MissingValues/Internals/NumberInfo.cs
+++ b/src/MissingValues/Internals/NumberInfo.cs
@@ -647,7 +647,7 @@ namespace MissingValues.Internals
 			return AssembleFloatingPointBits<TFloat, TBits>(completeMantissa, finalExponent, hasZeroTail);
 		}
 
-		private unsafe static TBits ConvertBigIntegerToFloatingPointBits<TFloat, TBits>(ref BigNumber value, uint integerBitsOfPrecision, bool hasNonZeroFractionalPart)
+		private static unsafe TBits ConvertBigIntegerToFloatingPointBits<TFloat, TBits>(ref BigNumber value, uint integerBitsOfPrecision, bool hasNonZeroFractionalPart)
 			where TFloat : struct, IBinaryFloatingPointInfo<TFloat, TBits>
 			where TBits : unmanaged, IBinaryInteger<TBits>, IUnsignedNumber<TBits>
 		{
@@ -716,24 +716,26 @@ namespace MissingValues.Internals
 				else // typeof(TBits) == typeof(UInt256)
 				{
 					// Otherwise, we need to read five blocks and combine them into a 256-bit mantissa
+					uint secondBottomBlockIndex = bottomBlockIndex--;
 					
 					exponent = baseExponent + ((int)(bottomBlockIndex) * 64);
+					exponent += (int)(topBlockBits);
 
 					int bottomBlockShift = (int)(topBlockBits);
-					int topBlockShift = 256 - bottomBlockShift;
+					int topBlockShift = size - bottomBlockShift;
 					int secondTopBlockShift = topBlockShift - 64;
 					int middleBlockShift = secondTopBlockShift - 64;
-
-					exponent += (int)(topBlockBits);
+					int secondBottomBlockShift = middleBlockShift - 64;
 
 					ulong bottomBlock = value.GetBlock(bottomBlockIndex);
 					ulong bottomBits = bottomBlock >> bottomBlockShift;
 
+					TBits secondBottomBits = TBits.CreateTruncating(value.GetBlock(secondBottomBlockIndex)) << secondBottomBlockShift;
 					TBits middleBits = TBits.CreateTruncating(value.GetBlock(middleBlockIndex)) << middleBlockShift;
 					TBits secondTopBits = TBits.CreateTruncating(value.GetBlock(secondTopBlockIndex)) << secondTopBlockShift;
 					TBits topBits = TBits.CreateTruncating(value.GetBlock(topBlockIndex)) << topBlockShift;
 
-					mantissa = topBits + secondTopBits + middleBits + TBits.CreateTruncating(bottomBits);
+					mantissa = topBits | secondTopBits | middleBits | secondBottomBits | TBits.CreateTruncating(bottomBits);
 
 					ulong unusedBottomBlockBitsMask = (1UL << (int)(topBlockBits)) - 1;
 					hasZeroTail &= (bottomBlock & unusedBottomBlockBitsMask) == 0;

--- a/src/MissingValues/Internals/NumberInfo.cs
+++ b/src/MissingValues/Internals/NumberInfo.cs
@@ -149,7 +149,7 @@ namespace MissingValues.Internals
 			{
 				result = TFloat.Zero;
 			}
-			else if (number.Scale > TFloat.OverflowDecimalExponent)
+			else if (number.Scale > TFloat.MaximumDecimalExponent)
 			{
 				result = TFloat.PositiveInfinity;
 			}

--- a/src/MissingValues/Octo.GenericMath.cs
+++ b/src/MissingValues/Octo.GenericMath.cs
@@ -63,7 +63,7 @@ public partial struct Octo :
 
 	static int IBinaryFloatingPointInfo<Octo, UInt256>.MinimumDecimalExponent => -78984;
 
-	static int IBinaryFloatingPointInfo<Octo, UInt256>.MaximumDecimalExponent => 78913;
+	static int IBinaryFloatingPointInfo<Octo, UInt256>.MaximumDecimalExponent => 78913 + 1;
 
 	static int IBinaryFloatingPointInfo<Octo, UInt256>.MinBiasedExponent => MinBiasedExponent;
 

--- a/src/MissingValues/Octo.GenericMath.cs
+++ b/src/MissingValues/Octo.GenericMath.cs
@@ -75,7 +75,7 @@ public partial struct Octo :
 
 	static int IBinaryFloatingPointInfo<Octo, UInt256>.ExponentBias => ExponentBias;
 
-	static int IBinaryFloatingPointInfo<Octo, UInt256>.OverflowDecimalExponent => (ExponentBias + (2 * 237) / 3);
+	static int IBinaryFloatingPointInfo<Octo, UInt256>.OverflowDecimalExponent => (ExponentBias + (2 * 237)) / 3;
 		
 	static int IBinaryFloatingPointInfo<Octo, UInt256>.InfinityExponent => 0x7FFFF;
 

--- a/src/MissingValues/Quad.GenericMath.cs
+++ b/src/MissingValues/Quad.GenericMath.cs
@@ -76,7 +76,7 @@ public partial struct Quad :
 
 	static int IBinaryFloatingPointInfo<Quad, UInt128>.ExponentBias => ExponentBias;
 
-	static int IBinaryFloatingPointInfo<Quad, UInt128>.OverflowDecimalExponent => (ExponentBias + (2 * 113) / 3);
+	static int IBinaryFloatingPointInfo<Quad, UInt128>.OverflowDecimalExponent => (ExponentBias + (2 * 113)) / 3;
 		
 	static int IBinaryFloatingPointInfo<Quad, UInt128>.InfinityExponent => 0x7FFF;
 

--- a/src/MissingValues/Quad.GenericMath.cs
+++ b/src/MissingValues/Quad.GenericMath.cs
@@ -64,7 +64,7 @@ public partial struct Quad :
 
 	static int IBinaryFloatingPointInfo<Quad, UInt128>.MinimumDecimalExponent => -4966;
 
-	static int IBinaryFloatingPointInfo<Quad, UInt128>.MaximumDecimalExponent => 4932;
+	static int IBinaryFloatingPointInfo<Quad, UInt128>.MaximumDecimalExponent => 4932 + 1;
 
 	static int IBinaryFloatingPointInfo<Quad, UInt128>.MinBiasedExponent => MinBiasedExponent;
 

--- a/tests/MissingValues.Tests/Data/OctoDataSources.cs
+++ b/tests/MissingValues.Tests/Data/OctoDataSources.cs
@@ -463,6 +463,9 @@ public class OctoDataSources
 	    yield return () => ("1.000", NumberStyles.Float, CultureInfo.InvariantCulture, Octo.One);
 	    yield return () => ("1,000.00", NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, Octo.Thousand);
 	    yield return () => ("-1,000.00", NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, Octo.NegativeThousand);
+	    
+	    yield return () => ("9.99999E80000", NumberStyles.Float, CultureInfo.InvariantCulture, Octo.PositiveInfinity);
+	    yield return () => ("1E-80000", NumberStyles.Float, CultureInfo.InvariantCulture, Octo.Zero);
     }
 
     public static IEnumerable<Func<(char[], NumberStyles, IFormatProvider?, Octo)>> ParseSpanTestData()
@@ -485,6 +488,9 @@ public class OctoDataSources
 	    yield return () => ("1.000".ToCharArray(), NumberStyles.Float, CultureInfo.InvariantCulture, Octo.One);
 	    yield return () => ("1,000.00".ToCharArray(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, Octo.Thousand);
 	    yield return () => ("-1,000.00".ToCharArray(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, Octo.NegativeThousand);
+	    
+	    yield return () => ("9.99999E80000".ToCharArray(), NumberStyles.Float, CultureInfo.InvariantCulture, Octo.PositiveInfinity);
+	    yield return () => ("1E-80000".ToCharArray(), NumberStyles.Float, CultureInfo.InvariantCulture, Octo.Zero);
     }
 
     public static IEnumerable<Func<(byte[], NumberStyles, IFormatProvider?, Octo)>> ParseUtf8TestData()
@@ -507,6 +513,9 @@ public class OctoDataSources
 	    yield return () => ("1.000"u8.ToArray(), NumberStyles.Float, CultureInfo.InvariantCulture, Octo.One);
 	    yield return () => ("1,000.00"u8.ToArray(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, Octo.Thousand);
 	    yield return () => ("-1,000.00"u8.ToArray(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, Octo.NegativeThousand);
+	    
+	    yield return () => ("9.99999E80000"u8.ToArray(), NumberStyles.Float, CultureInfo.InvariantCulture, Octo.PositiveInfinity);
+	    yield return () => ("1E-80000"u8.ToArray(), NumberStyles.Float, CultureInfo.InvariantCulture, Octo.Zero);
     }
 
     public static IEnumerable<Func<(string, NumberStyles, IFormatProvider?, bool, Octo)>> TryParseTestData()
@@ -529,6 +538,9 @@ public class OctoDataSources
 		yield return () => ("1.000", NumberStyles.Float, CultureInfo.InvariantCulture, true, Octo.One);
 		yield return () => ("1,000.00", NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, true, Octo.Thousand);
 		yield return () => ("-1,000.00", NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, true, Octo.NegativeThousand);
+		
+		yield return () => ("9.99999E80000", NumberStyles.Float, CultureInfo.InvariantCulture, true, Octo.PositiveInfinity);
+		yield return () => ("1E-80000", NumberStyles.Float, CultureInfo.InvariantCulture, true, Octo.Zero);
     }
 
     public static IEnumerable<Func<(char[], NumberStyles, IFormatProvider?, bool, Octo)>> TryParseSpanTestData()
@@ -551,6 +563,9 @@ public class OctoDataSources
 	    yield return () => ("1.000".ToCharArray(), NumberStyles.Float, CultureInfo.InvariantCulture, true, Octo.One);
 	    yield return () => ("1,000.00".ToCharArray(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, true, Octo.Thousand);
 	    yield return () => ("-1,000.00".ToCharArray(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, true, Octo.NegativeThousand);
+	    
+	    yield return () => ("9.99999E80000".ToCharArray(), NumberStyles.Float, CultureInfo.InvariantCulture, true, Octo.PositiveInfinity);
+	    yield return () => ("1E-80000".ToCharArray(), NumberStyles.Float, CultureInfo.InvariantCulture, true, Octo.Zero);
     }
 
     public static IEnumerable<Func<(byte[], NumberStyles, IFormatProvider?, bool, Octo)>> TryParseUtf8TestData()
@@ -573,6 +588,9 @@ public class OctoDataSources
 	    yield return () => ("1.000"u8.ToArray(), NumberStyles.Float, CultureInfo.InvariantCulture, true, Octo.One);
 	    yield return () => ("1,000.00"u8.ToArray(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, true, Octo.Thousand);
 	    yield return () => ("-1,000.00"u8.ToArray(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, true, Octo.NegativeThousand);
+	    
+	    yield return () => ("9.99999E80000"u8.ToArray(), NumberStyles.Float, CultureInfo.InvariantCulture, true, Octo.PositiveInfinity);
+	    yield return () => ("1E-80000"u8.ToArray(), NumberStyles.Float, CultureInfo.InvariantCulture, true, Octo.Zero);
     }
 
     public static IEnumerable<Func<(Octo, string, IFormatProvider?, string)>> ToStringTestData()

--- a/tests/MissingValues.Tests/Data/QuadDataSources.cs
+++ b/tests/MissingValues.Tests/Data/QuadDataSources.cs
@@ -464,6 +464,9 @@ public class QuadDataSources
 		yield return () => ("1.000", NumberStyles.Float, CultureInfo.InvariantCulture, Quad.One);
 		yield return () => ("1,000.00", NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, Quad.Thousand);
 		yield return () => ("-1,000.00", NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, Quad.NegativeThousand);
+
+		yield return () => ("9.99999E6000", NumberStyles.Float, CultureInfo.InvariantCulture, Quad.PositiveInfinity);
+		yield return () => ("1E-6000", NumberStyles.Float, CultureInfo.InvariantCulture, Quad.Zero);
     }
 
     public static IEnumerable<Func<(char[], NumberStyles, IFormatProvider?, Quad)>> ParseSpanTestData()
@@ -490,6 +493,9 @@ public class QuadDataSources
 	    yield return () => ("1.000".ToCharArray(), NumberStyles.Float, CultureInfo.InvariantCulture, Quad.One);
 	    yield return () => ("1,000.00".ToCharArray(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, Quad.Thousand);
 	    yield return () => ("-1,000.00".ToCharArray(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, Quad.NegativeThousand);
+	    
+	    yield return () => ("9.99999E6000".ToCharArray(), NumberStyles.Float, CultureInfo.InvariantCulture, Quad.PositiveInfinity);
+	    yield return () => ("1E-6000".ToCharArray(), NumberStyles.Float, CultureInfo.InvariantCulture, Quad.Zero);
     }
 
     public static IEnumerable<Func<(byte[], NumberStyles, IFormatProvider?, Quad)>> ParseUtf8TestData()
@@ -516,6 +522,9 @@ public class QuadDataSources
 	    yield return () => ("1.000"u8.ToArray(), NumberStyles.Float, CultureInfo.InvariantCulture, Quad.One);
 	    yield return () => ("1,000.00"u8.ToArray(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, Quad.Thousand);
 	    yield return () => ("-1,000.00"u8.ToArray(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, Quad.NegativeThousand);
+	    
+	    yield return () => ("9.99999E6000"u8.ToArray(), NumberStyles.Float, CultureInfo.InvariantCulture, Quad.PositiveInfinity);
+	    yield return () => ("1E-6000"u8.ToArray(), NumberStyles.Float, CultureInfo.InvariantCulture, Quad.Zero);
     }
 
     public static IEnumerable<Func<(string, NumberStyles, IFormatProvider?, bool, Quad)>> TryParseTestData()
@@ -543,6 +552,9 @@ public class QuadDataSources
 		yield return () => ("1.000", NumberStyles.Float, CultureInfo.InvariantCulture, true, Quad.One);
 		yield return () => ("1,000.00", NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, true, Quad.Thousand);
 		yield return () => ("-1,000.00", NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, true, Quad.NegativeThousand);
+		
+		yield return () => ("9.99999E6000", NumberStyles.Float, CultureInfo.InvariantCulture, true, Quad.PositiveInfinity);
+		yield return () => ("1E-6000", NumberStyles.Float, CultureInfo.InvariantCulture, true, Quad.Zero);
     }
 
     public static IEnumerable<Func<(char[], NumberStyles, IFormatProvider?, bool, Quad)>> TryParseSpanTestData()
@@ -570,6 +582,9 @@ public class QuadDataSources
 		yield return () => ("1.000".ToCharArray(), NumberStyles.Float, CultureInfo.InvariantCulture, true, Quad.One);
 		yield return () => ("1,000.00".ToCharArray(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, true, Quad.Thousand);
 		yield return () => ("-1,000.00".ToCharArray(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, true, Quad.NegativeThousand);
+		
+		yield return () => ("9.99999E6000".ToCharArray(), NumberStyles.Float, CultureInfo.InvariantCulture, true, Quad.PositiveInfinity);
+		yield return () => ("1E-6000".ToCharArray(), NumberStyles.Float, CultureInfo.InvariantCulture, true, Quad.Zero);
     }
 
     public static IEnumerable<Func<(byte[], NumberStyles, IFormatProvider?, bool, Quad)>> TryParseUtf8TestData()
@@ -597,6 +612,9 @@ public class QuadDataSources
 		yield return () => ("1.000"u8.ToArray(), NumberStyles.Float, CultureInfo.InvariantCulture, true, Quad.One);
 		yield return () => ("1,000.00"u8.ToArray(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, true, Quad.Thousand);
 		yield return () => ("-1,000.00"u8.ToArray(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, true, Quad.NegativeThousand);
+		
+		yield return () => ("9.99999E6000"u8.ToArray(), NumberStyles.Float, CultureInfo.InvariantCulture, true, Quad.PositiveInfinity);
+		yield return () => ("1E-6000"u8.ToArray(), NumberStyles.Float, CultureInfo.InvariantCulture, true, Quad.Zero);
     }
 
     public static IEnumerable<Func<(Quad, string, IFormatProvider?, string)>> ToStringTestData()


### PR DESCRIPTION
fixes #31 